### PR TITLE
Add remote shell payload for remote REPL.

### DIFF
--- a/payloads/remote_shell.py
+++ b/payloads/remote_shell.py
@@ -1,0 +1,215 @@
+from __future__ import print_function
+
+import sys
+import traceback
+from StringIO import StringIO
+from utils.conversion import u64_to_i64
+from utils.etc import alloc
+from utils.rp import log
+from sc import sc
+
+
+WRITING = False
+
+if WRITING:  # solo para que el editor se calle
+    port = 0
+    s = 0
+    sockaddr_in = bytearray()
+    len_buf = bytearray()
+
+
+PROMPT = "ps> "
+END_MARKER = "\n<<<END_OF_RESULT>>>\n"
+
+
+def handle_special_commands(cmd, ctx):
+    """
+    Comandos especiales tipo:
+      .exit / .quit
+      .vars         -> lista de nombres en el contexto
+      .dir nombre   -> dir(nombre)
+      .type nombre  -> type(nombre)
+      .repr nombre  -> repr(nombre)
+    """
+    stripped = cmd.strip()
+
+    if stripped in (".exit", "exit()", "quit()", ".quit"):
+        log("Exit requested.")
+        raise SystemExit
+
+    # .vars -> mostrar keys de ctx
+    if stripped == ".vars":
+        names = sorted(ctx.keys())
+        out = "Context variables:\n" + ", ".join(names) + "\n"
+        return out, ""
+
+    # .dir nombre
+    if stripped.startswith(".dir "):
+        name = stripped[5:].strip()
+        if name in ctx:
+            obj = ctx[name]
+            out = "dir(%s):\n%s\n" % (name, ", ".join(dir(obj)))
+        else:
+            out = "Name %r not found in context.\n" % name
+        return out, ""
+
+    # .type nombre
+    if stripped.startswith(".type "):
+        name = stripped[6:].strip()
+        if name in ctx:
+            obj = ctx[name]
+            out = "type(%s): %r\n" % (name, type(obj))
+        else:
+            out = "Name %r not found in context.\n" % name
+        return out, ""
+
+    # .repr nombre
+    if stripped.startswith(".repr "):
+        name = stripped[6:].strip()
+        if name in ctx:
+            obj = ctx[name]
+            out = "repr(%s): %r\n" % (name, obj)
+        else:
+            out = "Name %r not found in context.\n" % name
+        return out, ""
+
+    # Ningún comando especial
+    return None, None
+
+
+def handle_command(cmd, ctx):
+    log("handle_command() received cmd=%r" % cmd)
+
+    cmd = cmd.rstrip("\n")
+    if not cmd:
+        log("Empty command.")
+        return "", ""
+
+    # Primero intentamos comandos especiales tipo .dir, .vars, etc.
+    special_out, special_err = handle_special_commands(cmd, ctx)
+    if special_out is not None or special_err is not None:
+        return special_out or "", special_err or ""
+
+    stdout_buf = StringIO()
+    stderr_buf = StringIO()
+
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    sys.stdout = stdout_buf
+    sys.stderr = stderr_buf
+
+    try:
+        try:
+            code_obj = compile(cmd, "<remote>", "eval")
+            mode = "eval"
+            log("Compiled as eval.")
+        except SyntaxError:
+            code_obj = compile(cmd, "<remote>", "exec")
+            mode = "exec"
+            log("Compiled as exec.")
+
+        try:
+            if mode == "eval":
+                result = eval(code_obj, ctx, ctx)
+                # Para ver contenido de expresiones tipo "renpy"
+                if result is not None:
+                    print(repr(result))
+            else:
+                exec(code_obj, ctx, ctx)
+        except SystemExit:
+            raise
+        except Exception:
+            log("Exception while running code.")
+            traceback.print_exc(file=stderr_buf)
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+
+    out = stdout_buf.getvalue()
+    err = stderr_buf.getvalue()
+
+    if out:
+        log("stdout=%r" % out)
+    if err:
+        log("stderr=%r" % err)
+
+    return out, err
+
+
+# -----------------------------------------------------
+#  ACCEPT CONNECTION (reuse Stage-1 listener socket!)
+# -----------------------------------------------------
+buf1 = alloc(1)
+
+client_sock = u64_to_i64(sc.syscalls.accept(s, sockaddr_in, len_buf))
+
+# Send greeting
+greeting = (
+    "Remote Python console ready (Python 2.7).\n"
+    "Reusing Stage-1 listener socket.\n"
+    "Special commands: .exit, .quit, .vars, .dir name, .type name, .repr name\n"
+)
+sc.syscalls.write(client_sock, greeting, len(greeting))
+
+log("Accepted client_sock=%d" % client_sock)
+
+ctx = globals()
+log("Globals loaded into REPL context.")
+
+# -----------------------------------------------------
+#  REPL LOOP
+# -----------------------------------------------------
+while True:
+    log("Writing prompt.")
+    sc.syscalls.write(client_sock, PROMPT, len(PROMPT))
+
+    log("Reading command bytes...")
+    cmd_bytes = ""
+
+    # Read command line (1 byte at a time, buf1 es bytearray)
+    while True:
+        n = u64_to_i64(sc.syscalls.read(client_sock, buf1, 1))
+        log("read() returned %d" % n)
+
+        if n <= 0:
+            log("read <= 0, closing.")
+            sc.syscalls.close(client_sock)
+            raise SystemExit
+
+        # buf1[0] es un int 0–255; lo convertimos a char
+        c = chr(buf1[0])
+        log("Received raw byte: %r" % c)
+
+        cmd_bytes += c
+
+        if c == "\n":
+            log("Newline detected, end of command.")
+            break
+
+    # Now decode
+    log("Decoding cmd_bytes=%r" % cmd_bytes)
+    try:
+        cmd = cmd_bytes.decode("utf-8", "replace")
+    except Exception as e:
+        log("DECODE ERROR: %s" % e)
+        cmd = ""
+
+    log("Decoded command: %r" % cmd)
+
+    # Execute command
+    try:
+        out, err = handle_command(cmd, ctx)
+    except SystemExit:
+        bye = "Bye.\n"
+        sc.syscalls.write(client_sock, bye, len(bye))
+        sc.syscalls.close(client_sock)
+        break
+
+    # Send results
+    result = out + err
+    if result:
+        log("Sending result len=%d" % len(result))
+        sc.syscalls.write(client_sock, result, len(result))
+
+    sc.syscalls.write(client_sock, END_MARKER, len(END_MARKER))
+    log("END_MARKER sent.")

--- a/payloads/remote_shell.py
+++ b/payloads/remote_shell.py
@@ -1,10 +1,8 @@
-from __future__ import print_function
-
 import sys
 import traceback
-import pprint
 from StringIO import StringIO
 from constants import SYSCALL
+from errors.socket import SocketError
 from utils.conversion import u64_to_i64
 from utils.etc import alloc
 from utils.rp import log
@@ -12,7 +10,7 @@ from sc import sc
 
 WRITING = False
 
-if WRITING:  # solo para que el editor se calle
+if WRITING:
     port = 0
     s = 0
     sockaddr_in = bytearray()
@@ -21,30 +19,38 @@ if WRITING:  # solo para que el editor se calle
 PROMPT = "ps> "
 END_MARKER = "\n<<<END_OF_RESULT>>>\n"
 
-_pp = pprint.PrettyPrinter(indent=2, width=120, compact=False)
+SYSCALL["getpid"] = 20
+SYSCALL["kill"] = 37
+SIGKILL = 9
+
+def kill_game():
+    pid = u64_to_i64(sc.syscalls.getpid())
+    if pid < 0:
+        raise Exception(
+            "getpid failed with return value %d, error %d\n%s"
+            % (
+                pid,
+                sc.syscalls.getpid.errno,
+                sc.syscalls.getpid.get_error_string(),
+            )
+        )
+
+    ret = u64_to_i64(sc.syscalls.kill(pid, SIGKILL))
+    if ret < 0:
+        raise SocketError(
+            "kill failed with return value %d, error %d\n%s"
+            % (
+                ret,
+                sc.syscalls.kill.errno,
+                sc.syscalls.kill.get_error_string(),
+            )
+        )
 
 
-def test_syscall(name, *args):
-    try:
-        fn = getattr(sc.syscalls, name)
-    except Exception as e:
-        return False, "syscall '%s' not found: %s" % (name, e)
-
-    try:
-        res = fn(*args)
-        return True, "retorno: %r" % (res,)
-    except Exception as e:
-        return False, "error while calling '%s': %s" % (name, e)
-
-
+# CLI related
 def handle_special_commands(cmd, ctx):
     """
-    Comandos especiales tipo:
-      .exit / .quit
-      .vars         -> lista de nombres en el contexto
-      .dir nombre   -> dir(nombre)
-      .type nombre  -> type(nombre)
-      .repr nombre  -> repr(nombre)
+    Special commands
     """
     stripped = cmd.strip()
 
@@ -52,21 +58,23 @@ def handle_special_commands(cmd, ctx):
         log("Exit requested.")
         raise SystemExit
 
-    if stripped == ".test_syscall":
-        parts = stripped.split()
-        if len(parts) < 2:
-            return "Uso: .test_syscall <name> [args]\n", ""
+    if stripped.startswith(".load "):
+        name = stripped[6:].strip()
 
-        name = parts[1]
-        args = parts[2:]
+        # Ask client to send the addon payload
+        request = "__LOAD_REQUEST__:%s\n" % name
+        sc.syscalls.write(client_sock, request, len(request))
 
-        ok, msg = test_syscall(name, *args)
-        out = "OK: %s\n" % msg if ok else "FAIL: %s\n" % msg
-        return out, ""
+        # Do NOT produce output now, client will respond with code
+        return "", ""
+
+    if stripped == ".kill":
+        kill_game()
+        return "", ""
 
     if stripped == ".syscalls":
         names = sorted(SYSCALL.keys())
-        out = "Syscalls definidas:\n" + ", ".join(names) + "\n"
+        out = "Defined syscalls:\n" + ", ".join(names) + "\n"
         return out, ""
 
     # .vars -> mostrar keys de ctx
@@ -107,7 +115,7 @@ def handle_command(cmd, ctx):
         log("Empty command.")
         return "", ""
 
-    # Primero intentamos comandos especiales tipo .dir, .vars, etc.
+    # Primero intentamos comandos especiales tipo .vars, etc.
     special_out, special_err = handle_special_commands(cmd, ctx)
     if special_out is not None or special_err is not None:
         return special_out or "", special_err or ""
@@ -121,27 +129,16 @@ def handle_command(cmd, ctx):
     sys.stderr = stderr_buf
 
     try:
-        try:
-            code_obj = compile(cmd, "<remote>", "eval")
-            mode = "eval"
-            log("Compiled as eval.")
-        except SyntaxError:
-            code_obj = compile(cmd, "<remote>", "exec")
-            mode = "exec"
-            log("Compiled as exec.")
-
-        try:
-            if mode == "eval":
-                result = eval(code_obj, ctx, ctx)
-                if result is not None:
-                    print(_pp.pformat(result))
-            else:
-                exec code_obj in ctx, ctx
-        except SystemExit:
-            raise
-        except Exception:
-            log("Exception while running code.")
-            traceback.print_exc(file=stderr_buf)
+        code_obj = compile(cmd, "<remote>", "eval")
+        log("Compiled as eval.")
+        result = eval(code_obj, ctx, ctx)
+        if result is not None:
+            print(repr(result))
+    except SystemExit:
+        raise
+    except Exception:
+        log("Exception while running code.")
+        traceback.print_exc(file=stderr_buf)
     finally:
         sys.stdout = old_stdout
         sys.stderr = old_stderr
@@ -156,81 +153,111 @@ def handle_command(cmd, ctx):
 
     return out, err
 
+def handle_addon(client_sock, cmd):
+    buf1 = alloc(1)
+    name = cmd.split(":", 1)[1].strip()
+    code = ""
 
-# -----------------------------------------------------
-#  ACCEPT CONNECTION (reuse Stage-1 listener socket!)
-# -----------------------------------------------------
-buf1 = alloc(1)
-
-client_sock = u64_to_i64(sc.syscalls.accept(s, sockaddr_in, len_buf))
-
-# Send greeting
-greeting = (
-    "Remote Python console ready (Python 2.7).\n"
-    "Reusing Stage-1 listener socket.\n"
-    "Special commands: .exit, .quit, .vars, .dir name, .type name, .repr name\n"
-)
-sc.syscalls.write(client_sock, greeting, len(greeting))
-
-log("Accepted client_sock=%d" % client_sock)
-
-ctx = globals()
-log("Globals loaded into REPL context.")
-
-# -----------------------------------------------------
-#  REPL LOOP
-# -----------------------------------------------------
-while True:
-    log("Writing prompt.")
-    sc.syscalls.write(client_sock, PROMPT, len(PROMPT))
-
-    log("Reading command bytes...")
-    cmd_bytes = ""
-
-    # Read command line (1 byte at a time, buf1 es bytearray)
+    # Read until we encounter __LOAD_END__
     while True:
         n = u64_to_i64(sc.syscalls.read(client_sock, buf1, 1))
-        log("read() returned %d" % n)
-
         if n <= 0:
-            log("read <= 0, closing.")
-            sc.syscalls.close(client_sock)
-            raise SystemExit
-
-        # buf1[0] es un int 0–255; lo convertimos a char
-        c = chr(buf1[0])
-        log("Received raw byte: %r" % c)
-
-        cmd_bytes += c
-
-        if c == "\n":
-            log("Newline detected, end of command.")
             break
 
-    # Now decode
-    log("Decoding cmd_bytes=%r" % cmd_bytes)
+        c = chr(buf1[0])
+        code += c
+
+        if code.endswith("__LOAD_END__"):
+            code = code[:-len("__LOAD_END__")]  # strip marker
+            break
+
+    # Execute addon code
     try:
-        cmd = cmd_bytes.decode("utf-8", "replace")
+        exec compile(code, "<addon:%s>" % name, "exec") in ctx, ctx
+        msg = "Addon '%s' loaded successfully.\n" % name
     except Exception as e:
-        log("DECODE ERROR: %s" % e)
-        cmd = ""
+        msg = "Addon '%s' failed: %s\n" % (name, e)
 
-    log("Decoded command: %r" % cmd)
-
-    # Execute command
-    try:
-        out, err = handle_command(cmd, ctx)
-    except SystemExit:
-        bye = "Bye.\n"
-        sc.syscalls.write(client_sock, bye, len(bye))
-        sc.syscalls.close(client_sock)
-        break
-
-    # Send results
-    result = out + err
-    if result:
-        log("Sending result len=%d" % len(result))
-        sc.syscalls.write(client_sock, result, len(result))
-
+    sc.syscalls.write(client_sock, msg, len(msg))
     sc.syscalls.write(client_sock, END_MARKER, len(END_MARKER))
-    log("END_MARKER sent.")
+
+# Outer loop
+while True:
+    log("Waiting for incoming connection...")
+    client_sock = u64_to_i64(sc.syscalls.accept(s, sockaddr_in, len_buf))
+    log("Accepted client_sock=%d" % client_sock)
+
+    buf1 = alloc(1)
+
+    # Send greeting
+    greeting = (
+        "Remote Python console ready (Python 2.7).\n"
+        "Reusing Stage-1 listener socket.\n"
+        "Special commands: .exit, .quit, .vars, .type name, .repr name\n"
+    )
+    sc.syscalls.write(client_sock, greeting, len(greeting))
+
+    ctx = globals()
+    log("Globals loaded into REPL context.")
+
+    # -----------------------------------------------------
+    #  Inner REPL loop
+    # -----------------------------------------------------
+    while True:
+        log("Writing prompt.")
+        sc.syscalls.write(client_sock, PROMPT, len(PROMPT))
+
+        log("Reading command bytes...")
+        cmd_bytes = ""
+
+        # Read command line (1 byte at a time)
+        while True:
+            n = u64_to_i64(sc.syscalls.read(client_sock, buf1, 1))
+
+            if n <= 0:
+                log("read <= 0, closing.")
+                sc.syscalls.close(client_sock)
+                raise SystemExit
+
+            c = chr(buf1[0])
+            cmd_bytes += c
+
+            if c == "\n":
+                log("Newline detected, end of command.")
+                break
+
+        # Now decode
+        log("Decoding cmd_bytes=%r" % cmd_bytes)
+        try:
+            cmd = cmd_bytes.decode("utf-8", "replace")
+        except Exception as e:
+            log("DECODE ERROR: %s" % e)
+            cmd = ""
+
+        # Load addon
+        try:
+            if cmd.startswith("__LOAD_BEGIN__:"):
+                handle_addon(client_sock, cmd)
+                continue
+        except Exception as e:
+            log("Addon load ERROR: %s" % e)
+            cmd = ""
+
+        log("Decoded command: %r" % cmd)
+
+        # Execute command
+        try:
+            out, err = handle_command(cmd, ctx)
+        except SystemExit:
+            bye = "Bye.\n"
+            sc.syscalls.write(client_sock, bye, len(bye))
+            sc.syscalls.close(client_sock)
+            break
+
+        # Send results
+        result = out + err
+        if result:
+            log("Sending result len=%d" % len(result))
+            sc.syscalls.write(client_sock, result, len(result))
+
+        sc.syscalls.write(client_sock, END_MARKER, len(END_MARKER))

--- a/payloads/remote_shell.py
+++ b/payloads/remote_shell.py
@@ -2,12 +2,13 @@ from __future__ import print_function
 
 import sys
 import traceback
+import pprint
 from StringIO import StringIO
+from constants import SYSCALL
 from utils.conversion import u64_to_i64
 from utils.etc import alloc
 from utils.rp import log
 from sc import sc
-
 
 WRITING = False
 
@@ -17,9 +18,23 @@ if WRITING:  # solo para que el editor se calle
     sockaddr_in = bytearray()
     len_buf = bytearray()
 
-
 PROMPT = "ps> "
 END_MARKER = "\n<<<END_OF_RESULT>>>\n"
+
+_pp = pprint.PrettyPrinter(indent=2, width=120, compact=False)
+
+
+def test_syscall(name, *args):
+    try:
+        fn = getattr(sc.syscalls, name)
+    except Exception as e:
+        return False, "syscall '%s' not found: %s" % (name, e)
+
+    try:
+        res = fn(*args)
+        return True, "retorno: %r" % (res,)
+    except Exception as e:
+        return False, "error while calling '%s': %s" % (name, e)
 
 
 def handle_special_commands(cmd, ctx):
@@ -37,20 +52,27 @@ def handle_special_commands(cmd, ctx):
         log("Exit requested.")
         raise SystemExit
 
+    if stripped == ".test_syscall":
+        parts = stripped.split()
+        if len(parts) < 2:
+            return "Uso: .test_syscall <name> [args]\n", ""
+
+        name = parts[1]
+        args = parts[2:]
+
+        ok, msg = test_syscall(name, *args)
+        out = "OK: %s\n" % msg if ok else "FAIL: %s\n" % msg
+        return out, ""
+
+    if stripped == ".syscalls":
+        names = sorted(SYSCALL.keys())
+        out = "Syscalls definidas:\n" + ", ".join(names) + "\n"
+        return out, ""
+
     # .vars -> mostrar keys de ctx
     if stripped == ".vars":
         names = sorted(ctx.keys())
         out = "Context variables:\n" + ", ".join(names) + "\n"
-        return out, ""
-
-    # .dir nombre
-    if stripped.startswith(".dir "):
-        name = stripped[5:].strip()
-        if name in ctx:
-            obj = ctx[name]
-            out = "dir(%s):\n%s\n" % (name, ", ".join(dir(obj)))
-        else:
-            out = "Name %r not found in context.\n" % name
         return out, ""
 
     # .type nombre
@@ -111,11 +133,10 @@ def handle_command(cmd, ctx):
         try:
             if mode == "eval":
                 result = eval(code_obj, ctx, ctx)
-                # Para ver contenido de expresiones tipo "renpy"
                 if result is not None:
-                    print(repr(result))
+                    print(_pp.pformat(result))
             else:
-                exec(code_obj, ctx, ctx)
+                exec code_obj in ctx, ctx
         except SystemExit:
             raise
         except Exception:

--- a/payloads/shell/dumps.py
+++ b/payloads/shell/dumps.py
@@ -1,0 +1,35 @@
+from sc import sc
+from utils.unsafe import readbuf
+
+global client_sock
+
+# Transfers
+def xfer_begin(x_type, name, size=-1):
+    hdr  = "__XFER_BEGIN__\n"
+    hdr += "TYPE:%s\n"  % x_type
+    hdr += "NAME:%s\n"  % name
+    hdr += "SIZE:%d\n"  % size
+    hdr += "__XFER_START__\n"
+    sc.syscalls.write(client_sock, hdr, len(hdr))
+
+def xfer_data(data):
+    # data must be a byte string (safe)
+    sc.syscalls.write(client_sock, data, len(data))
+
+def xfer_end():
+    tail = "__XFER_END__\n"
+    sc.syscalls.write(client_sock, tail, len(tail))
+
+# Dumps
+def memdump(addr, length):
+    xfer_begin("BIN", "mem_%x" % addr, length)
+    buf = readbuf(addr, length)
+    xfer_data(buf)
+    xfer_end()
+
+def dump_dict(d):
+    xfer_begin("KV", "dict_dump", -1)
+    for k, v in d.items():
+        line = "KEY:%r VAL:%r\n" % (k, v)
+        xfer_data(line)
+    xfer_end()

--- a/payloads/shell/test.py
+++ b/payloads/shell/test.py
@@ -1,0 +1,5 @@
+global dump_dict, renpy
+
+def foo():
+    l = { "test": True, "name": renpy.config.name }
+    dump_dict(l)

--- a/remote_client.py
+++ b/remote_client.py
@@ -1,0 +1,67 @@
+import socket
+import sys
+
+END_MARKER = b"\n<<<END_OF_RESULT>>>\n"
+
+
+def recv_until(sock, marker):
+    data = bytearray()
+
+    while True:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data.extend(chunk)
+        if marker in data:
+            break
+
+    parts = data.split(marker, 1)
+    return parts[0].decode("utf-8", errors="ignore")
+
+
+def main(host, port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+
+    # Read initial greeting (may also include first prompt)
+    try:
+        s.settimeout(0.25)
+        init = s.recv(4096)
+        if init:
+            sys.stdout.write(init.decode("utf-8", errors="ignore"))
+            sys.stdout.flush()
+    except socket.timeout:
+        pass
+    finally:
+        s.settimeout(None)
+
+    while True:
+        # Local prompt
+        sys.stdout.write("ps> ")
+        sys.stdout.flush()
+
+        # User input
+        line = sys.stdin.readline()
+        if not line:
+            break
+
+        s.sendall(line.encode("utf-8"))
+
+        # Read execution result
+        result = recv_until(s, END_MARKER)
+        if result:
+            sys.stdout.write(result)
+            sys.stdout.flush()
+
+        if line.strip() in (".exit", "quit()", "exit()", ".quit"):
+            break
+
+    s.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: remote_client.py <ip> <port>")
+        sys.exit(1)
+
+    main(sys.argv[1], int(sys.argv[2]))

--- a/remote_client.py
+++ b/remote_client.py
@@ -1,6 +1,7 @@
 import socket
 import sys
 import os
+import transfers as xfer
 
 END_MARKER = b"\n<<<END_OF_RESULT>>>\n"
 
@@ -93,6 +94,22 @@ def main(host, port):
 
         # Normal command, send to remote
         s.sendall(line.encode("utf-8"))
+
+        # NEW: check for XFER stream
+        peek = s.recv(4096, socket.MSG_PEEK)
+        if b"__XFER_BEGIN__" in peek:
+            # process dump
+            x_type, name, raw = xfer.recv_xfer(s)
+            xfer.handle_xfer(x_type, name, raw)
+
+            # IMPORTANT: clean leftover END_MARKER
+            try:
+                peek_after = s.recv(len(END_MARKER), socket.MSG_PEEK)
+                if END_MARKER in peek_after:
+                    s.recv(len(END_MARKER))
+            except:
+                pass
+            continue
 
         # Read result
         result = recv_until(s, END_MARKER)

--- a/remote_client.py
+++ b/remote_client.py
@@ -1,12 +1,12 @@
 import socket
 import sys
+import os
 
 END_MARKER = b"\n<<<END_OF_RESULT>>>\n"
 
 
 def recv_until(sock, marker):
     data = bytearray()
-
     while True:
         chunk = sock.recv(4096)
         if not chunk:
@@ -14,40 +14,87 @@ def recv_until(sock, marker):
         data.extend(chunk)
         if marker in data:
             break
-
     parts = data.split(marker, 1)
     return parts[0].decode("utf-8", errors="ignore")
+
+
+def send_addon(sock, name):
+    """
+    Sends the contents of a local addon file from ./shell/<name>.py
+    to the remote shell.
+    """
+    path = os.path.join("./payloads/shell", name + ".py")
+
+    if not os.path.exists(path):
+        print("Addon not found:", path)
+        return
+
+    with open(path, "r") as f:
+        contents = f.read()
+
+    header = "__LOAD_BEGIN__:%s\n" % name
+    sock.sendall(header.encode("utf-8"))
+    sock.sendall(contents.encode("utf-8"))
+    sock.sendall("__LOAD_END__".encode("utf-8"))
+
+    # Wait for remote ack
+    result = recv_until(sock, END_MARKER)
+    sys.stdout.write(result)
+    sys.stdout.flush()
 
 
 def main(host, port):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((host, port))
 
-    # Read initial greeting (may also include first prompt)
+    # Initial greeting
     try:
         s.settimeout(0.25)
         init = s.recv(4096)
         if init:
             sys.stdout.write(init.decode("utf-8", errors="ignore"))
-            sys.stdout.flush()
     except socket.timeout:
         pass
     finally:
         s.settimeout(None)
 
     while True:
-        # Local prompt
         sys.stdout.write("ps> ")
         sys.stdout.flush()
 
-        # User input
         line = sys.stdin.readline()
         if not line:
             break
 
+        # Check if local client should intercept command
+        if line.startswith(".load "):
+            # Send the .load command to remote
+            s.sendall(line.encode("utf-8"))
+
+            # Expect __LOAD_REQUEST__ from remote
+            resp = recv_until(s, END_MARKER)
+            if "__LOAD_REQUEST__:" in resp:
+                # Extract clean request
+                idx = resp.find("__LOAD_REQUEST__:")
+                req_line = resp[idx:].strip()
+
+                # Now parse name
+                reqname = req_line.split(":", 1)[1].strip()
+
+                # Send addon to remote
+                send_addon(s, reqname)
+                continue
+            else:
+                # Unexpected output
+                sys.stdout.write(resp)
+                sys.stdout.flush()
+
+            continue
+
+        # Normal command, send to remote
         s.sendall(line.encode("utf-8"))
 
-        # Read execution result
+        # Read result
         result = recv_until(s, END_MARKER)
         if result:
             sys.stdout.write(result)

--- a/transfers.py
+++ b/transfers.py
@@ -1,0 +1,179 @@
+import sys
+import json
+
+
+def recv_xfer(sock):
+    """
+    Receives XFER block:
+
+        __XFER_BEGIN__
+        TYPE:<type>
+        NAME:<name>
+        SIZE:<size>
+        __XFER_START__
+        <raw bytes>
+        __XFER_END__
+
+    Implements:
+      - progress bar (if SIZE >= 0)
+      - size validation
+    """
+    header_buf = ""
+
+    # Wait for header
+    while "__XFER_BEGIN__" not in header_buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            return None, None, None
+        try:
+            header_buf += chunk.decode("utf-8", "ignore")
+        except:
+            return None, None, None
+
+    lines = header_buf.splitlines()
+    try:
+        idx = lines.index("__XFER_BEGIN__")
+    except ValueError:
+        return None, None, None
+
+    x_type = None
+    name = None
+    declared_size = -1
+
+    # Parse metadata
+    for line in lines[idx+1:]:
+        if line.startswith("TYPE:"):
+            x_type = line[5:]
+        elif line.startswith("NAME:"):
+            name = line[5:]
+        elif line.startswith("SIZE:"):
+            try:
+                declared_size = int(line[5:])
+            except:
+                declared_size = -1
+        elif line == "__XFER_START__":
+            break
+
+    raw = bytearray()
+    show_progress = (declared_size >= 0)
+
+    # Progress banner
+    if show_progress:
+        sys.stdout.write("Receiving %d bytes...\n" % declared_size)
+        sys.stdout.flush()
+
+    # Read payload
+    while True:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+
+        raw.extend(chunk)
+
+        # detect end marker
+        pos = raw.find(b"__XFER_END__")
+        if pos != -1:
+            raw = raw[:pos]
+            break
+
+        # live progress bar
+        if show_progress:
+            received = len(raw)
+            if declared_size > 0:
+                pct = int((received * 100) / declared_size)
+                if pct > 100:
+                    pct = 100
+                bar_len = 40
+                filled = int((pct * bar_len) / 100)
+                bar = "#" * filled + "." * (bar_len - filled)
+                sys.stdout.write("\r[%s] %d%% (%d/%d)" %
+                                 (bar, pct, received, declared_size))
+                sys.stdout.flush()
+
+    if show_progress:
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    # Size validation
+    if declared_size >= 0:
+        actual = len(raw)
+        if actual != declared_size:
+            sys.stdout.write("[WARNING] Expected %d bytes but received %d bytes.\n" %
+                             (declared_size, actual))
+            sys.stdout.flush()
+
+    return x_type, name, raw
+
+
+# ----------------------------------------------------------
+# SAVING FUNCTIONS
+# ----------------------------------------------------------
+
+def save_bin(name, raw):
+    fn = name + ".bin"
+    with open(fn, "wb") as f:
+        f.write(raw)
+    print("[saved BIN to %s]" % fn)
+
+
+def save_text(name, raw):
+    fn = name + ".txt"
+    with open(fn, "w") as f:
+        f.write(raw.decode("utf-8", "ignore"))
+    print("[saved TEXT to %s]" % fn)
+
+
+def save_kv(name, raw):
+    fn = name + ".txt"
+    with open(fn, "w") as f:
+        f.write(raw.decode("utf-8", "ignore"))
+    print("[saved KV to %s]" % fn)
+
+
+def save_json(name, raw):
+    """
+    raw contains lines: repr_key:repr_value
+    """
+    text = raw.decode("utf-8", "ignore")
+    out = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        parts = line.split(":", 1)
+        if len(parts) != 2:
+            continue
+        try:
+            k = eval(parts[0])
+            v = eval(parts[1])
+            out[k] = v
+        except:
+            pass
+
+    fn = name + ".json"
+    with open(fn, "w") as f:
+        json.dump(out, f, indent=2)
+    print("[saved JSON to %s]" % fn)
+
+
+def save_raw(name, raw):
+    fn = name + ".raw"
+    with open(fn, "wb") as f:
+        f.write(raw)
+    print("[saved RAW to %s]" % fn)
+
+
+def handle_xfer(x_type, name, raw):
+    """Dispatch saving based on type."""
+    if not name:
+        name = "dump"
+
+    if x_type == "BIN":
+        save_bin(name, raw)
+    elif x_type == "TEXT":
+        save_text(name, raw)
+    elif x_type == "KV":
+        save_kv(name, raw)
+    elif x_type == "JSON":
+        save_json(name, raw)
+    else:
+        save_raw(name, raw)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive remote Python REPL over TCP with session controls, inspection commands, captured stdout/stderr, and clear result delimiters.
  * Companion interactive client supporting greetings/timeouts, .load addon uploads, and robust command/response handling.
  * Simple transfer protocol and receiver for streaming dumps (binary/text/kv/json) with local save helpers.
  * Utilities to stream memory and dictionary dumps from the remote and a small test addon to exercise dumping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->