### PR TITLE
stream log output back to client socket, fix persistent save

### DIFF
--- a/payloads/force_persistent.py
+++ b/payloads/force_persistent.py
@@ -111,7 +111,7 @@ def main():
     log("Injecting YARPE trigger into persistent object...")
 
     p.yarpe_trigger = Yummy()
-    p._changed = True   # Forces Ren'Py to rewrite persistent safely
+    p._changed["yarpe_trigger"] = True   # Forces Ren'Py to rewrite persistent safely
 
     # ---------------------------------------------------------
     # Re-pickle persistent (protocol 2) and recompress

--- a/src/main.py
+++ b/src/main.py
@@ -164,7 +164,8 @@ def poc():
 
         log("Received payload, executing...")
 
-        close_socket(client_sock)  # close client socket
+        # Keep client_sock open so payloads can write output back
+        SHARED_VARS["client_sock"] = client_sock
 
         # Execute code, mimic file-exec by throwing local/global in same scope
         scope = dict(globals(), **locals())
@@ -174,6 +175,9 @@ def poc():
         except:
             exc_msg = traceback.format_exc()
             log_exc(exc_msg)
+        finally:
+            SHARED_VARS.pop("client_sock", None)
+            close_socket(client_sock)
 
     close_socket(s)  # close listening socket
 

--- a/src/main.py
+++ b/src/main.py
@@ -164,8 +164,11 @@ def poc():
 
         log("Received payload, executing...")
 
-        # Keep client_sock open so payloads can write output back
+        # Keep client_sock open so payload log can be sent back
         SHARED_VARS["client_sock"] = client_sock
+
+        from utils.rp import payload_log
+        payload_log[:] = []
 
         # Execute code, mimic file-exec by throwing local/global in same scope
         scope = dict(globals(), **locals())
@@ -176,6 +179,12 @@ def poc():
             exc_msg = traceback.format_exc()
             log_exc(exc_msg)
         finally:
+            try:
+                if payload_log:
+                    write_to_socket(client_sock, "".join(payload_log).encode("utf-8"))
+            except:
+                pass
+            payload_log[:] = []
             SHARED_VARS.pop("client_sock", None)
             close_socket(client_sock)
 

--- a/src/main.py
+++ b/src/main.py
@@ -182,7 +182,7 @@ def poc():
             try:
                 if payload_log:
                     write_to_socket(client_sock, "".join(payload_log).encode("utf-8"))
-            except:
+            except Exception:
                 pass
             payload_log[:] = []
             SHARED_VARS.pop("client_sock", None)

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import os
 import pygame_sdl2
 from pygame_sdl2 import CONTROLLER_BUTTON_Y
 from utils.fs import file_exists, read_file_data
-from utils.rp import log, log_exc
+from utils.rp import log, log_exc, payload_log
 from utils.tcp import (
     create_tcp_client,
     create_tcp_server,
@@ -167,7 +167,6 @@ def poc():
         # Keep client_sock open so payload log can be sent back
         SHARED_VARS["client_sock"] = client_sock
 
-        from utils.rp import payload_log
         payload_log[:] = []
 
         # Execute code, mimic file-exec by throwing local/global in same scope

--- a/src/utils/rp.py
+++ b/src/utils/rp.py
@@ -42,9 +42,13 @@ debug_char = rp.store.Character(
 )
 
 
+payload_log = []
+
+
 def log(*args):
     global debug_log
-    strings = " ".join([str(arg) for arg in list(args)]).split("\n")
+    msg = " ".join([str(arg) for arg in list(args)])
+    strings = msg.split("\n")
     debug_log.extend(strings)
     if len(debug_log) > 32:
         debug_log = debug_log[-32:]
@@ -52,14 +56,8 @@ def log(*args):
     rp.game.invoke_in_new_context(debug_char, full_msg)
 
     from constants import SHARED_VARS
-    sock = SHARED_VARS.get("client_sock")
-    if sock is not None:
-        try:
-            from utils.tcp import write_to_socket
-            msg = " ".join([str(arg) for arg in list(args)]) + "\n"
-            write_to_socket(sock, msg.encode("utf-8"))
-        except:
-            pass
+    if SHARED_VARS.get("client_sock") is not None:
+        payload_log.append(msg + "\n")
 
 
 def log_exc(string):

--- a/src/utils/rp.py
+++ b/src/utils/rp.py
@@ -51,6 +51,16 @@ def log(*args):
     full_msg = "{nw}" + "\n".join(debug_log)
     rp.game.invoke_in_new_context(debug_char, full_msg)
 
+    from constants import SHARED_VARS
+    sock = SHARED_VARS.get("client_sock")
+    if sock is not None:
+        try:
+            from utils.tcp import write_to_socket
+            msg = " ".join([str(arg) for arg in list(args)]) + "\n"
+            write_to_socket(sock, msg.encode("utf-8"))
+        except:
+            pass
+
 
 def log_exc(string):
     global exception_occurred


### PR DESCRIPTION
use `cat payload.py | nc -q 0 <ip> 9025` and you will get logs back over the socket with log() function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients now receive accumulated execution logs as a single response after payloads finish running.
* **Bug Fixes**
  * Improved connection handling so responses are delivered reliably and sockets are closed only after responses are sent.
* **Chores**
  * Internal logging now captures and buffers output for deferred delivery to clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->